### PR TITLE
add missed header in utils_test

### DIFF
--- a/src/tests/utils_test.c
+++ b/src/tests/utils_test.c
@@ -6,6 +6,7 @@
  */
 
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>


### PR DESCRIPTION
Test utils_test is being compiled on MUSL produces [error](https://bugs.gentoo.org/836740): 

`utils_test.c:15:1: error: unknown type name int8_t`

This PR fixes it.